### PR TITLE
allow a map[string]interface{} to be provided as the params also

### DIFF
--- a/Template.go
+++ b/Template.go
@@ -183,6 +183,8 @@ func (t *Template) fileToXMLStruct(fname string) *xmlNode {
 func (t *Template) Params(v interface{}) {
 	// t.params = collectParams("", v)
 	switch val := v.(type) {
+	case map[string]interface{}:
+		t.params = mapToParams(val)
 	case string:
 		t.params = JSONToParams([]byte(val))
 	case []byte:


### PR DESCRIPTION
In my use case I have a simple key/value list (not any hierarchy) and a map[string]interface{} is apparently natively supported, just was not exposed publicly -- this change exposes it publicly so that we don't have to create a dynamic struct at runtime using reflect and can instead just send the map