### PR TITLE
Optimize template replacement speed

### DIFF
--- a/ImageProcesser.go
+++ b/ImageProcesser.go
@@ -52,7 +52,7 @@ func processImage(img *Image) (imgXMLStr string, err error) {
 				Space: "",
 				Local: "Default",
 			},
-			Attrs: []xml.Attr{
+			Attrs: []*xml.Attr{
 				{Name: xml.Name{Space: "", Local: "Extension"}, Value: imgExt},
 				{Name: xml.Name{Space: "", Local: "ContentType"}, Value: "image/" + imgExt},
 			},
@@ -76,7 +76,7 @@ func processImage(img *Image) (imgXMLStr string, err error) {
 			Space: "",
 			Local: "Relationship",
 		},
-		Attrs: []xml.Attr{
+		Attrs: []*xml.Attr{
 			{Name: xml.Name{Space: "", Local: "Id"}, Value: rid},
 			{Name: xml.Name{Space: "", Local: "Type"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"},
 			{Name: xml.Name{Space: "", Local: "Target"}, Value: "media/" + imgPath},

--- a/Template.go
+++ b/Template.go
@@ -137,7 +137,7 @@ func OpenTemplateWithURL(docurl string) (tpl *Template, err error) {
 func (t *Template) Params(v any) {
 	// t.params = collectParams("", v)
 	switch val := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		t.params = mapToParams(val)
 	case string:
 		t.params = JSONToParams([]byte(val))

--- a/Template.helpers.go
+++ b/Template.helpers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"log"
+	"strings"
 )
 
 // Convert given bytes to struct of xml nodes
@@ -118,4 +119,35 @@ func (t *Template) matchBrokenLeftPlaceholder(content string) bool {
 // Match right placeholder part `}}`
 func (t *Template) matchBrokenRightPlaceholder(content string) bool {
 	return t.matchBrokenPlaceholder(content, false)
+}
+
+func (t Template) GetContentPrefixList(content []byte) []string {
+	var ret []string
+	var record strings.Builder
+	start := false
+	length := len(content)
+	for i, v := range content {
+		if i == 0 {
+			continue
+		}
+
+		if v == '{' && content[i-1] == '{' {
+			start = true
+			continue
+		}
+		if start {
+			if v == ' ' || (v == '}' && length-1 > i && content[i+1] == '}') {
+				ret = append(ret, record.String())
+				record.Reset()
+				start = false
+			}
+			if v == '.' {
+				ret = append(ret, record.String())
+				record.Reset()
+				continue
+			}
+			record.WriteByte(v)
+		}
+	}
+	return ret
 }

--- a/t.docx_bench_test.go
+++ b/t.docx_bench_test.go
@@ -1,0 +1,68 @@
+package docxplate_test
+
+import (
+	"log"
+	"testing"
+
+	"github.com/bobiverse/docxplate"
+)
+
+func BenchmarkLists100(b *testing.B) {
+	var user = User{
+		Name: "Walter",
+	}
+	for i := 0; i < 100; i++ {
+		user.Friends = append(user.Friends, &User{Name: "Bob", Age: 28})
+	}
+
+	tdoc, _ := docxplate.OpenTemplate("test-data/lists.docx")
+	tdoc.Params(user)
+	if err := tdoc.ExportDocx("test-data/~test-lists.docx"); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func BenchmarkLists200(b *testing.B) {
+	var user = User{
+		Name: "Walter",
+	}
+	for i := 0; i < 200; i++ {
+		user.Friends = append(user.Friends, &User{Name: "Bob", Age: 28})
+	}
+
+	tdoc, _ := docxplate.OpenTemplate("test-data/lists.docx")
+	tdoc.Params(user)
+	if err := tdoc.ExportDocx("test-data/~test-lists.docx"); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func BenchmarkLists400(b *testing.B) {
+	var user = User{
+		Name: "Walter",
+	}
+	for i := 0; i < 400; i++ {
+		user.Friends = append(user.Friends, &User{Name: "Bob", Age: 28})
+	}
+
+	tdoc, _ := docxplate.OpenTemplate("test-data/lists.docx")
+	tdoc.Params(user)
+	if err := tdoc.ExportDocx("test-data/~test-lists.docx"); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func BenchmarkLists1000(b *testing.B) {
+	var user = User{
+		Name: "Walter",
+	}
+	for i := 0; i < 1000; i++ {
+		user.Friends = append(user.Friends, &User{Name: "Bob", Age: 28})
+	}
+
+	tdoc, _ := docxplate.OpenTemplate("test-data/lists.docx")
+	tdoc.Params(user)
+	if err := tdoc.ExportDocx("test-data/~test-lists.docx"); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
1. fix ```clone()``` set parent method
2. optimize ```expandPlaceholders(xnode *xmlNode)``` ,reduce loop time
3. optimize ```replaceSingleParams(xnode *xmlNode, triggerParamOnly bool)```,reduce loop time

before:

```
goos: linux
goarch: amd64
pkg: github.com/bobiverse/docxplate
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
BenchmarkLists100-6     1000000000               0.4386 ns/op
BenchmarkLists200-6            1        1693713947 ns/op
BenchmarkLists400-6            1        6552133541 ns/op
BenchmarkLists1000-6           1        40482876671 ns/op
PASS
ok      github.com/bobiverse/docxplate  60.426s
```

after:

```
goos: linux
goarch: amd64
pkg: github.com/bobiverse/docxplate
cpu: Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
BenchmarkLists100-6     1000000000               0.01451 ns/op
BenchmarkLists200-6     1000000000               0.02569 ns/op
BenchmarkLists400-6     1000000000               0.04924 ns/op
BenchmarkLists1000-6    1000000000               0.1187 ns/op
PASS
ok      github.com/bobiverse/docxplate  3.301s
```
